### PR TITLE
Added store module functionality for subscription event

### DIFF
--- a/modules/PrimaryPool/src/kv_out.rs
+++ b/modules/PrimaryPool/src/kv_out.rs
@@ -5,12 +5,11 @@ use substreams::store::{self, DeltaProto};
 use substreams_sink_kv::pb::sf::substreams::sink::kv::v1::KvOperations;
 // use substreams_sink_kv::pb::kv::KvOperations;
 use crate::pb;
-use crate::pb::verified::primary::v1::Pool;
-use pb::verified::primary::v1::Subscription;
+use crate::pb::verified::primary::v1::{Pool,Subscription, Subscriptions};
 
 // use crate::pb::eth::block_meta::v1::BlockMeta;
 
-pub fn process_deltas(ops: &mut KvOperations, deltas: store::Deltas<DeltaProto<Pool>>) {
+pub fn process_deltas(ops: &mut KvOperations, deltas: store::Deltas<DeltaProto<Subscription>>) {
     use substreams::pb::substreams::store_delta::Operation;
 
     for delta in deltas.deltas {

--- a/modules/PrimaryPool/substreams.yaml
+++ b/modules/PrimaryPool/substreams.yaml
@@ -40,11 +40,26 @@ modules:
     output:
       type: proto:verified.primary.v1.Subscription
 
+  - name: store_subscription_created
+    kind: store
+    updatePolicy: set
+    valueType: proto:verified.primary.v1.Subscription
+    inputs:
+      - map: map_subscriptions
+
+  - name: map_subscriptions_check
+    kind: map
+    initialBlock: 9561662
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_subscription_created
+    output:
+      type: proto:verified.primary.v1.Subscription
+
   - name: kv_out
     kind: map
     inputs:
-      - store: store_pools_created
+      - store: store_subscription_created
         mode: deltas
     output:
       type: proto:sf.substreams.sink.kv.v1.KVOperations
-

--- a/modules/SecondaryPool/src/lib.rs
+++ b/modules/SecondaryPool/src/lib.rs
@@ -76,37 +76,6 @@ fn map_trades(blk: eth::Block, pools_store: StoreGetProto<Pool>) -> Result<Trade
 }
 
 // #[substreams::handlers::map]
-// fn map_trades(
-//     blk: eth::Block,
-//     pool_created: Pools,
-// ) -> Result<verified::secondary::v1::Trades, substreams::errors::Error> {
-//     log::info!("Detecting trades from Secondary pools");
-//     let mut all_trades = Vec::new();
-//     for pool in pool_created.pools {
-//         let trades_for_pool: Vec<_> = blk
-//             .events::<abi::pool::events::TradeReport>(&[&pool.pool_address])
-//             .map(|(trade_reported, _log)| {
-//                 log::info!("TradeReport event seen");
-
-//                 Trade {
-//                     security_address: trade_reported.security,
-//                     order_ref:trade_reported.order_ref.to_vec(),
-//                     party:trade_reported.party,
-//                     counterparty:trade_reported.counterparty,
-//                     order_type: trade_reported.order_type.to_vec(),
-//                     price: trade_reported.price.to_u64(),
-//                     currency_address: trade_reported.currency,
-//                     traded_amount: trade_reported.amount.to_u64(),
-//                     execution_date: trade_reported.execution_date.to_u64(),
-//                 }
-//             })
-//             .collect();
-//         all_trades.extend(trades_for_pool);
-//     }
-//     Ok(verified::secondary::v1::Trades { trades: all_trades })
-// }
-
-// #[substreams::handlers::map]
 pub fn kv_out(trade_reported: Trade) -> Result<KvOperations, Error> {
     // Create an empty 'KvOperations' structure
     let mut kv_ops: KvOperations = Default::default();


### PR DESCRIPTION
Note: Helper function/module named `map_subscriptions_check`.
`map_subscriptions_check` used to help us log the store module of subscription event.
to run `map_subscriptions_check` 
run- `substreams run -e goerli.eth.streamingfast.io:443 substreams.yaml map_subscriptions_check --start-block 9561662 --stop-block +21 --debug-modules-output=map_pools,store_pools_created,map_subscriptions,store_subscription_created,map_subscriptions_check`